### PR TITLE
Show match scores

### DIFF
--- a/script/typing/check
+++ b/script/typing/check
@@ -6,4 +6,4 @@ if [ -z "$MYPY" ]; then
     MYPY=mypy
 fi
 
-exec "$MYPY" sr tests "$@"
+exec "$MYPY" setup.py sr tests "$@"

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ exclude =
     script,
     tests/dummy
 ignore =
+    # Don't worry about shadowing built-in module names. Modules are namespaced
+    # anyway, so this is far less a concern than other built-in shadowing.
+    A005
     # Don't require set literals
     C401
     C405

--- a/sr/comp/cli/command_line.py
+++ b/sr/comp/cli/command_line.py
@@ -22,6 +22,7 @@ from . import (
     scorer,
     shift_matches,
     show_league_table,
+    show_match_scores,
     show_schedule,
     summary,
     top_match_points,
@@ -66,6 +67,7 @@ def argument_parser() -> argparse.ArgumentParser:
     scorer.add_subparser(subparsers)
     shift_matches.add_subparser(subparsers)
     show_league_table.add_subparser(subparsers)
+    show_match_scores.add_subparser(subparsers)
     show_schedule.add_subparser(subparsers)
     summary.add_subparser(subparsers)
     top_match_points.add_subparser(subparsers)

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -1,6 +1,9 @@
 __description__ = "Show the game and league points achieved for each match"
 
 from typing import Dict, List, Union, NamedTuple
+from sr.comp.types import TLA, GamePoints, ArenaName, MatchNumber
+from sr.comp.scores import LeaguePosition
+from sr.comp.ranker import LeaguePoints
 
 
 DISPLAY_NAME_WIDTH = 18
@@ -8,15 +11,15 @@ ARENA_NAME_WIDTH = 12
 
 
 class MatchCorner(NamedTuple):
-    tla: str
-    ranking: Union[int, str]  # to allow "???" to be used for unknown scores
-    game: Union[int, str]
-    league: Union[int, str]
+    tla: TLA
+    ranking: Union[LeaguePosition, str]  # to allow "???" to be used for unknown scores
+    game: Union[GamePoints, str]
+    league: Union[LeaguePoints, str]
 
 
 class MatchResult(NamedTuple):
-    num: int
-    arena: str
+    num: MatchNumber
+    arena: ArenaName
     display_name: str
     corners: Dict[int, MatchCorner]
 

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -162,8 +162,7 @@ def command(settings):
         skip_filter = False
         # validate TLA exists
         if filter_tla not in comp.teams.keys():
-            print('TLA not found')
-            return
+            exit(f"TLA {filter_tla!r} not recognised")
 
     if not settings.all and skip_filter:
         # get the index of the last scored match
@@ -185,8 +184,7 @@ def command(settings):
         )
 
     if len(match_results) == 0:
-        print("No matches found for current filters")
-        return
+        exit("No matches found for current filters")
 
     num_teams_per_arena = comp.num_teams_per_arena
 
@@ -220,12 +218,13 @@ def add_subparser(subparsers):
         nargs='?',
         help="filter to matches containing this TLA (ignores --limit)",
     )
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         '--all',
         action='store_true',
         help="show all matches (overrides --limit)",
     )
-    parser.add_argument(
+    group.add_argument(
         '--limit',
         default=15,
         help="how many recently scored matches to show (default: %(default)s)",

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -141,7 +141,7 @@ def command(settings):
 
     # TODO hide arena column w/ single arena?
 
-    num_teams_per_arena = getattr(comp, 'num_teams_per_arena', len(comp.corners))
+    num_teams_per_arena = comp.num_teams_per_arena
 
     print_heading(num_teams_per_arena, display_name_width, arena_name_width)
 

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -3,7 +3,6 @@ __description__ = "Show the game and league points achieved for each match"
 from typing import Dict, List, Union, NamedTuple
 from sr.comp.types import TLA, GamePoints, ArenaName, MatchNumber
 from sr.comp.scores import LeaguePosition
-from sr.comp.ranker import LeaguePoints
 
 
 DISPLAY_NAME_WIDTH = 18
@@ -14,7 +13,7 @@ class MatchCorner(NamedTuple):
     tla: TLA
     ranking: Union[LeaguePosition, str]  # to allow "???" to be used for unknown scores
     game: Union[GamePoints, str]
-    league: Union[LeaguePoints, str]
+    league: Union[int, str]
 
 
 class MatchResult(NamedTuple):

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -50,12 +50,20 @@ def collect_match_info(comp, match) -> MatchResult:
     for corner, team in enumerate(match.teams):
         match_id = (match.arena, match.num)
 
-        corner_data[corner] = MatchCorner(
-            tla=team,
-            ranking=ranking[team],
-            game=game_points[team],
-            league=league_points[team],
-        )
+        if team:  # corner occupied
+            corner_data[corner] = MatchCorner(
+                tla=team,
+                ranking=ranking[team],
+                game=game_points[team],
+                league=league_points[team],
+            )
+        else:
+            corner_data[corner] = MatchCorner(
+                tla='',
+                ranking='',
+                game='',
+                league='',
+            )
 
     return MatchResult(
         num=match.num,

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -1,8 +1,9 @@
-__description__ = "Show the game and league points achieved for each match"
+from typing import Dict, List, NamedTuple, Optional
 
-from typing import Dict, List, Optional, NamedTuple
-from sr.comp.types import TLA, GamePoints, ArenaName, MatchNumber
 from sr.comp.scores import LeaguePosition
+from sr.comp.types import ArenaName, GamePoints, MatchNumber, TLA
+
+__description__ = "Show the game and league points achieved for each match"
 
 
 class MatchCorner(NamedTuple):
@@ -19,7 +20,7 @@ class MatchResult(NamedTuple):
     corners: Dict[int, MatchCorner]
 
 
-def collect_match_info(comp, match) -> MatchResult:
+def collect_match_info(comp, match):
     from sr.comp.match_period import MatchType
     from sr.comp.scores import degroup
 
@@ -74,7 +75,7 @@ def collect_match_info(comp, match) -> MatchResult:
 
 
 def print_col(text):
-        print(text, end='|')
+    print(text, end='|')
 
 
 def print_heading(num_corners, name_width, arena_name_width):
@@ -85,7 +86,7 @@ def print_heading(num_corners, name_width, arena_name_width):
 
     print_col("Display Name".center(name_width))
     print_col("Arena".center(arena_name_width))
-    for idx in range(num_corners):
+    for _ in range(num_corners):
         print_col("TLA".center(5))
         print_col("Rank")
         print_col("Game")
@@ -93,7 +94,7 @@ def print_heading(num_corners, name_width, arena_name_width):
     print()
 
 
-def print_match(match: MatchResult, name_width, arena_name_width):
+def print_match(match: MatchResult, name_width: int, arena_name_width: int) -> None:
     print_col(match.display_name.center(name_width))
     print_col(match.arena.center(arena_name_width))
 

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -114,7 +114,10 @@ def generate_displayed_match(match: MatchResult, num_corners: int) -> List[List[
 
         displayed_corners.append(displayed_corner)
 
+    # wrap the number of zones to the DISPLAYED_ZONES constant
     for corner in range(0, num_corners, DISPLAYED_ZONES):
+        # first row displays the match and arena information,
+        # any extra rows leave this field blank
         if corner == 0:
             match_row = [f"{match.display_name} in {match.arena}"]
         else:
@@ -124,6 +127,7 @@ def generate_displayed_match(match: MatchResult, num_corners: int) -> List[List[
             try:
                 match_row.extend(displayed_corners[corner + idx])
             except IndexError:
+                # pad the number of corners out to a multiple of DISPLAYED_ZONES
                 match_row.extend(['', '', '', ''])
 
         displayed_match.append(match_row)

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -125,7 +125,7 @@ def command(settings):
         )
 
     if len(match_results) == 0:
-        print("Not matches found, TLA may be invalid")
+        print("No matches found, TLA may be invalid")
         return
 
     # Calculate "Display Name" and "Arena" column widths

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -116,11 +116,9 @@ def command(settings):
 
     # Calculate "Display Name" and "Arena" column widths
     display_name_width = 12  # start with width of label
-    for match in match_results:
-        display_name_width = max(display_name_width, len(match.display_name))
-
     arena_name_width = 5  # start with width of label
     for match in match_results:
+        display_name_width = max(display_name_width, len(match.display_name))
         arena_name_width = max(arena_name_width, len(match.arena))
 
     # TODO hide arena column w/ single arena?

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -5,10 +5,6 @@ from sr.comp.types import TLA, GamePoints, ArenaName, MatchNumber
 from sr.comp.scores import LeaguePosition
 
 
-DISPLAY_NAME_WIDTH = 18
-ARENA_NAME_WIDTH = 12
-
-
 class MatchCorner(NamedTuple):
     tla: TLA
     ranking: Union[LeaguePosition, str]  # to allow "???" to be used for unknown scores

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -156,7 +156,7 @@ def command(settings):
             comp.scores.last_scored_match,
         ) + 1  # include last scored match in results
         scan_matches = comp.schedule.matches[
-            max(0, end_match-int(settings.limit)):end_match
+            max(0, end_match - int(settings.limit)):end_match
         ]
     else:
         scan_matches = comp.schedule.matches

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -67,27 +67,35 @@ def collect_match_info(comp, match) -> MatchResult:
     )
 
 
+def print_col(text):
+        print(text, end='|')
+
+
 def print_heading(num_corners, name_width, arena_name_width):
-    print(f" {' ':{name_width + 3 + arena_name_width}} |", end='')
+    print_col("".center(name_width + 1 + arena_name_width))
     for idx in range(num_corners):
-        print(f"{f'Zone {idx}':^22}|", end='')
+        print_col(f"Zone {idx}".center(22))
     print()
-    print(f" {'Display Name':^{name_width}} | {'Arena':^{arena_name_width}} |", end='')
+
+    print_col("Display Name".center(name_width))
+    print_col("Arena".center(arena_name_width))
     for idx in range(num_corners):
-        print(f" {'TLA':<4}|{'Rank':>4}|{'Game':>4}|{'League':>6}|", end='')
+        print_col("TLA".center(5))
+        print_col("Rank")
+        print_col("Game")
+        print_col("League")
     print()
 
 
 def print_match(match: MatchResult, name_width, arena_name_width):
-    print(
-        f" {match.display_name:^{name_width}} | {match.arena:^{arena_name_width}} |",
-        end='',
-    )
+    print_col(match.display_name.center(name_width))
+    print_col(match.arena.center(arena_name_width))
+
     for corner in match.corners.values():
-        print(
-            f" {corner.tla:<4}|{corner.ranking:>3} |{corner.game:>3} |{corner.league:>5} |",
-            end='',
-        )
+        print_col(f" {corner.tla:<4}")
+        print_col(f"{corner.ranking:>3} ")
+        print_col(f"{corner.game:>3} ")
+        print_col(f"{corner.league:>5} ")
     print()
 
 
@@ -120,6 +128,10 @@ def command(settings):
     for match in match_results:
         display_name_width = max(display_name_width, len(match.display_name))
         arena_name_width = max(arena_name_width, len(match.arena))
+
+    # Add some padding
+    display_name_width += 2
+    arena_name_width += 2
 
     # TODO hide arena column w/ single arena?
 

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -1,0 +1,148 @@
+__description__ = "Show the game and league points achieved for each match"
+
+from typing import Dict, List, Union, NamedTuple
+
+
+DISPLAY_NAME_WIDTH = 18
+ARENA_NAME_WIDTH = 12
+
+
+class MatchCorner(NamedTuple):
+    tla: str
+    ranking: Union[int, str]  # to allow "???" to be used for unknown scores
+    game: Union[int, str]
+    league: Union[int, str]
+
+
+class MatchResult(NamedTuple):
+    num: int
+    arena: str
+    display_name: str
+    corners: Dict[int, MatchCorner]
+
+
+def collect_match_info(comp, match) -> MatchResult:
+    from sr.comp.match_period import MatchType
+    from sr.comp.scores import degroup
+
+    if match.type == MatchType.knockout:
+        score_data = comp.scores.knockout
+    elif match.type == MatchType.tiebreaker:
+        score_data = comp.scores.tiebreaker
+    elif match.type == MatchType.league:
+        score_data = comp.scores.league
+
+    match_id = (match.arena, match.num)
+
+    if match_id in score_data.game_points:
+        league_points = score_data.ranked_points[match_id]
+        game_points = score_data.game_points[match_id]
+        ranking = degroup(score_data.game_positions[match_id])
+    else:
+        league_points = {}
+        game_points = {}
+        ranking = {}
+        for team in match.teams:
+            league_points[team] = "???"
+            game_points[team] = "???"
+            ranking[team] = "???"
+
+    corner_data: Dict[int, MatchCorner] = {}
+
+    for corner, team in enumerate(match.teams):
+        match_id = (match.arena, match.num)
+
+        corner_data[corner] = MatchCorner(
+            tla=team,
+            ranking=ranking[team],
+            game=game_points[team],
+            league=league_points[team],
+        )
+
+    return MatchResult(
+        num=match.num,
+        arena=match.arena,
+        display_name=match.display_name,
+        corners=corner_data,
+    )
+
+
+def print_heading(num_corners, name_width, arena_name_width):
+    print(f" {' ':{name_width + 3 + arena_name_width}} |", end='')
+    for idx in range(num_corners):
+        print(f"{f'Zone {idx}':^22}|", end='')
+    print()
+    print(f" {'Display Name':^{name_width}} | {'Arena':^{arena_name_width}} |", end='')
+    for idx in range(num_corners):
+        print(f" {'TLA':<4}|{'Rank':>4}|{'Game':>4}|{'League':>6}|", end='')
+    print()
+
+
+def print_match(match: MatchResult, name_width, arena_name_width):
+    print(
+        f" {match.display_name:^{name_width}} | {match.arena:^{arena_name_width}} |",
+        end='',
+    )
+    for corner in match.corners.values():
+        print(
+            f" {corner.tla:<4}|{corner.ranking:>3} |{corner.game:>3} |{corner.league:>5} |",
+            end='',
+        )
+    print()
+
+
+def command(settings):
+    import os.path
+
+    from sr.comp.comp import SRComp
+
+    comp = SRComp(os.path.realpath(settings.compstate))
+
+    match_results: List[MatchResult] = []
+
+    filter_tla = settings.tla
+
+    for slots in comp.schedule.matches:
+        match_results.extend(
+            collect_match_info(comp, match)
+            for match in slots.values()
+            if not filter_tla or filter_tla in match.teams
+        )
+
+    if len(match_results) == 0:
+        print("Not matches found, TLA may be invalid")
+        return
+
+    # Calculate "Display Name" and "Arena" column widths
+    display_name_width = 12  # start with width of label
+    for match in match_results:
+        display_name_width = max(display_name_width, len(match.display_name))
+
+    arena_name_width = 5  # start with width of label
+    for match in match_results:
+        arena_name_width = max(arena_name_width, len(match.arena))
+
+    # TODO hide arena column w/ single arena?
+
+    print_heading(len(match_results[0].corners), display_name_width, arena_name_width)
+
+    for match in match_results:
+        print_match(match, display_name_width, arena_name_width)
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        'show-match-scores',
+        help=__description__,
+        description=__description__,
+    )
+    parser.add_argument(
+        'compstate',
+        help="competition state repo",
+    )
+    parser.add_argument(
+        'tla',
+        nargs='?',
+        help="filter to matches containing this TLA",
+    )
+    parser.set_defaults(func=command)

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -156,7 +156,14 @@ def command(settings):
     match_results: List[MatchResult] = []
 
     filter_tla = settings.tla
-    skip_filter = filter_tla is None
+    skip_filter = True
+
+    if filter_tla is not None:
+        skip_filter = False
+        # validate TLA exists
+        if filter_tla not in comp.teams.keys():
+            print('TLA not found')
+            return
 
     if not settings.all and skip_filter:
         # get the index of the last scored match
@@ -178,7 +185,7 @@ def command(settings):
         )
 
     if len(match_results) == 0:
-        print("No matches found, TLA may be invalid")
+        print("No matches found for current filters")
         return
 
     num_teams_per_arena = comp.num_teams_per_arena

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -101,12 +101,13 @@ def command(settings):
     match_results: List[MatchResult] = []
 
     filter_tla = settings.tla
+    skip_filter = not filter_tla
 
     for slots in comp.schedule.matches:
         match_results.extend(
             collect_match_info(comp, match)
             for match in slots.values()
-            if not filter_tla or filter_tla in match.teams
+            if filter_tla in match.teams or skip_filter
         )
 
     if len(match_results) == 0:

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -1,15 +1,15 @@
 __description__ = "Show the game and league points achieved for each match"
 
-from typing import Dict, List, Union, NamedTuple
+from typing import Dict, List, Optional, NamedTuple
 from sr.comp.types import TLA, GamePoints, ArenaName, MatchNumber
 from sr.comp.scores import LeaguePosition
 
 
 class MatchCorner(NamedTuple):
     tla: TLA
-    ranking: Union[LeaguePosition, str]  # to allow "???" to be used for unknown scores
-    game: Union[GamePoints, str]
-    league: Union[int, str]
+    ranking: Optional[LeaguePosition]
+    game: Optional[GamePoints]
+    league: Optional[int]
 
 
 class MatchResult(NamedTuple):
@@ -41,9 +41,9 @@ def collect_match_info(comp, match) -> MatchResult:
         game_points = {}
         ranking = {}
         for team in match.teams:
-            league_points[team] = "???"
-            game_points[team] = "???"
-            ranking[team] = "???"
+            league_points[team] = None
+            game_points[team] = None
+            ranking[team] = None
 
     corner_data: Dict[int, MatchCorner] = {}
 
@@ -97,11 +97,11 @@ def print_match(match: MatchResult, name_width, arena_name_width):
     print_col(match.display_name.center(name_width))
     print_col(match.arena.center(arena_name_width))
 
-    for corner in match.corners.values():
-        print_col(f" {corner.tla:<4}")
-        print_col(f"{corner.ranking:>3} ")
-        print_col(f"{corner.game:>3} ")
-        print_col(f"{corner.league:>5} ")
+    for tla, ranking, game, league in match.corners.values():
+        print_col(f" {tla:<4}")
+        print_col(f"{'??' if ranking is None else ranking:>3} ")
+        print_col(f"{'???' if game is None else game:>3} ")
+        print_col(f"{'??' if league is None else league:>5} ")
     print()
 
 

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -115,7 +115,7 @@ def command(settings):
     match_results: List[MatchResult] = []
 
     filter_tla = settings.tla
-    skip_filter = not filter_tla
+    skip_filter = filter_tla is None
 
     for slots in comp.schedule.matches:
         match_results.extend(

--- a/sr/comp/cli/show_match_scores.py
+++ b/sr/comp/cli/show_match_scores.py
@@ -123,7 +123,9 @@ def command(settings):
 
     # TODO hide arena column w/ single arena?
 
-    print_heading(len(match_results[0].corners), display_name_width, arena_name_width)
+    num_teams_per_arena = getattr(comp, 'num_teams_per_arena', len(comp.corners))
+
+    print_heading(num_teams_per_arena, display_name_width, arena_name_width)
 
     for match in match_results:
         print_match(match, display_name_width, arena_name_width)


### PR DESCRIPTION
Prints ranking. league and match points for every match.
Matches can be filtered to a single team.

Output format is:
```
$ srcomp show-match-scores dummy-comp HRS
                      |        Zone 0        |        Zone 1        |
 Display Name | Arena | TLA |Rank|Game|League| TLA |Rank|Game|League|
   Match 5    |   A   | BGS |  1 | 10 |    8 | HRS |  4 |  1 |    2 |
   Match 10   |   B   | SCC |  2 |  6 |    6 | DSF |  1 |  8 |    8 |
   Match 16   |   A   | QEH |  1 |  7 |    8 | HRS |  4 |  3 |    2 |
...
```